### PR TITLE
A couple of fixes for ac_fs/ac_fs_copy()

### DIFF
--- a/src/ac_fs.c
+++ b/src/ac_fs.c
@@ -128,6 +128,7 @@ ssize_t ac_fs_copy(const char *from, const char *to, int flags)
 	int ret;
 	int oflags = O_EXCL;
 	unsigned window = 0;
+	ssize_t total = 0;
 	ssize_t bytes_wrote = -1;
 	struct stat sb;
 
@@ -165,6 +166,9 @@ ssize_t ac_fs_copy(const char *from, const char *to, int flags)
 
 	do {
 		bytes_wrote = sendfile(ofd, ifd, NULL, IO_SIZE);
+		if (bytes_wrote == -1)
+			break;
+		total += bytes_wrote;
 
 		/*
 		 * Try not to blow the page cache. After each sendfile() we
@@ -196,5 +200,5 @@ cleanup:
 	close(ifd);
 	close(ofd);
 
-	return bytes_wrote;
+	return bytes_wrote == -1 ? bytes_wrote : total;
 }


### PR DESCRIPTION
A couple of fixes for the ac_fs_copy() function

 - Be sure to make _all_ the sync_file_range(2) & posix_fadvise(2) calls.
 - When returning the number of bytes written, return the _total_ bytes writen.