### PR TITLE
ac_net: Include netinet/in.h

### DIFF
--- a/src/ac_net.c
+++ b/src/ac_net.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <netdb.h>
 #include <arpa/inet.h>
 


### PR DESCRIPTION
This is for the definitions of struct sockaddr_in, struct sockaddr_in6
etc. Linux must have been getting these somehow, but FreeBSD wasn't.

Either way, technically this header should be included.
