### PR TITLE
Enable FreeBSD build test on cirrus-ci.org

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,10 @@
+freebsd_instance:
+  image_family: freebsd-13-0
+  cpu: 1
+  memory: 1G
+
+task:
+  name: freebsd_13 (clang)
+  skip: "!changesInclude('.cirrus.yml', 'Makefile', 'src/**')"
+  install_script: pkg install -y gmake e2fsprogs-libuuid
+  script: CFLAGS=-Werror gmake CC=clang V=1


### PR DESCRIPTION
This runs in a FreeBSD 13.0 VM and uses clang.

It should only trigger on updates to; Makefile, src/ & .cirrus.yml

It adds -Werror to the CFLAGS to try and keep a warning free build.