### PR TITLE
test: Fix a compiler warnings under clang

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -135,9 +135,9 @@ static void byte_test(void)
 			"not ");
 
 	byte = 0x24;
-	printf("Lower nibble of byte(0x24) : %hhu\n",
+	printf("Lower nibble of byte(0x24) : %d\n",
 			AC_BYTE_NIBBLE_LOW(byte));
-	printf("Upper nibble of byte(0x24) : %hhu\n",
+	printf("Upper nibble of byte(0x24) : %d\n",
                         AC_BYTE_NIBBLE_HIGH(byte));
 
 	printf("*** %s\n\n", __func__);


### PR DESCRIPTION
When compiling under clang the following warnings are produced

test.c:139:4: warning: format specifies type 'unsigned char' but the argument has type 'unsigned int' [-Wformat]
                        AC_BYTE_NIBBLE_LOW(byte));
                        ^~~~~~~~~~~~~~~~~~~~~~~~
./include/libac.h:60:35: note: expanded from macro 'AC_BYTE_NIBBLE_LOW'
                                  ^~~~~~~~~~~~~~~~
test.c:141:25: warning: format specifies type 'unsigned char' but the argument has type 'unsigned int' [-Wformat]
                        AC_BYTE_NIBBLE_HIGH(byte));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~
./include/libac.h:59:35: note: expanded from macro 'AC_BYTE_NIBBLE_HIGH'
                                  ^~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.

We were using %hhu as the format specifier (seeing as we were working on
a u8 and GCC is happy with that) but clang thinks it should be %d, maybe
it's right?

Anyway just use %d as GCC is also happy with that...