### PR TITLE
ac_net: Have ac_net_port_from_sa() return -1 on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ functions.
 
 #### ac\_net\_port\_from\_sa - extract the port number from a struct sockaddr
 
-    u16 ac_net_port_from_sa(const struct sockaddr *sa);
+    int ac_net_port_from_sa(const struct sockaddr *sa);
 
 #### ac\_net\_inet\_pton - address family agnostic wrapper around inet\_pton(3)
 

--- a/src/ac_net.c
+++ b/src/ac_net.c
@@ -3,7 +3,7 @@
 /*
  * ac_net.c - Network related functions
  *
- * Copyright (c) 2017 - 2018, 2020 - 2021	Andrew Clayton
+ * Copyright (c) 2017 - 2018, 2020 - 2022	Andrew Clayton
  *						<andrew@digital-domain.net>
  */
 
@@ -33,9 +33,9 @@
  *
  * Returns:
  *
- * The port number in host byte order or 0 for an unknown address family
+ * The port number in host byte order or -1 for an unknown address family
  */
-u16 ac_net_port_from_sa(const struct sockaddr *sa)
+int ac_net_port_from_sa(const struct sockaddr *sa)
 {
 	switch (sa->sa_family) {
 	case AF_INET6:
@@ -43,7 +43,7 @@ u16 ac_net_port_from_sa(const struct sockaddr *sa)
 	case AF_INET:
 		return ntohs(((struct sockaddr_in *)sa)->sin_port);
 	default:
-		return 0;
+		return -1;
 	}
 }
 

--- a/src/include/libac.h
+++ b/src/include/libac.h
@@ -3,7 +3,7 @@
 /*
  * libac.h - Miscellaneous functions
  *
- * Copyright (c) 2017 - 2020 - 2021	Andrew Clayton
+ * Copyright (c) 2017 - 2020 - 2022	Andrew Clayton
  *					<andrew@digital-domain.net>
  */
 
@@ -334,7 +334,7 @@ extern int ac_cmp_ptr(const void *a, const void *b);
 extern int ac_cmp_str(const void *a, const void *b);
 extern int ac_cmp_u32(const void *a, const void *b);
 
-extern u16 ac_net_port_from_sa(const struct sockaddr *sa);
+extern int ac_net_port_from_sa(const struct sockaddr *sa);
 extern int ac_net_inet_pton(const char *src, void *dst);
 extern const char *ac_net_inet_ntop(const void *src, char *dst, socklen_t size);
 extern int ac_net_ns_lookup_by_host(const struct addrinfo *hints,

--- a/src/test.c
+++ b/src/test.c
@@ -646,8 +646,8 @@ static void net_test(void)
 	if (err)
 		perror("ac_net_ns_lookup_by_ip");
 
-	printf("Port : %hu\n", ac_net_port_from_sa((struct sockaddr *)&in6));
-	printf("Port : %hu\n", ac_net_port_from_sa((struct sockaddr *)&in4));
+	printf("Port : %d\n", ac_net_port_from_sa((struct sockaddr *)&in6));
+	printf("Port : %d\n", ac_net_port_from_sa((struct sockaddr *)&in4));
 
 	getaddrinfo("www.google.com", "443", &hints, &res);
 	printf("www.google.com -> %s -> ", ac_net_inet_ntop(


### PR DESCRIPTION
Currently 0 is used to indicate an error from ac_net_port_from_sa(),
however it is maybe possible[0] (though unlikely/unusual) that you could
have a port number of 0 in the various sockaddr structures.

It may be wise to cater for this situation.

Make ac_net_port_from_sa() return an int rather than a u16 and have it
return -1 rather than 0 on error.

[0]: https://daniel.haxx.se/blog/2014/10/25/pretending-port-zero-is-a-normal-one/
