### PR TITLE
Revert "ac_net: Update a cast in __ipv4_isin()"

### DIFF
--- a/src/ac_net.c
+++ b/src/ac_net.c
@@ -175,7 +175,7 @@ static inline bool __ipv4_isin(const char *network, u8 cidr,
 
 	inet_pton(AF_INET, network, &net_addr);
 
-	ip_addr.s_addr = addr->s_addr & htonl(~0U << (32 - cidr));
+	ip_addr.s_addr = addr->s_addr & htonl(~0UL << (32 - cidr));
 
 	return ip_addr.s_addr == net_addr.s_addr;
 }


### PR DESCRIPTION
This reverts commit 525d696cf4ce7333429200e523e6587fe7c46c2e.

Casting to UL prevents potentially undefined behaviour if cidr is 0 and
we would then be shifting a 32 bit value by 32 bits, with the cast it
means we're shifting a 64 bit value by 32 bits.

The original point of the commit was to fix a compiler warning when
compiling with -Wconversion, which we don't and there are other places
in the code which trip up on that anyway.
