### PR TITLE
ac_fs: Fix potential issue in ac_fs_mkdir_p()

### DIFF
--- a/src/ac_fs.c
+++ b/src/ac_fs.c
@@ -16,6 +16,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <errno.h>
 
 #include "include/libac.h"
@@ -73,15 +74,15 @@ int ac_fs_mkdir_p(int dirfd, const char *path, mode_t mode)
 {
 	char *dir;
 	char *ptr;
-	char mdir[4096] = "\0";
+	char mdir[PATH_MAX + 1] = "\0";	/* +1 for a trailing '/' */
 	int ret = 0;
 
-	if (strlen(path) >= sizeof(mdir)) {
+	if (strlen(path) >= PATH_MAX) {
 		errno = ENAMETOOLONG;
 		return -1;
 	}
 
-	if (*path == '/')
+	if (*path != '/')
 		strcat(mdir, "/");
 
 	dir = strdup(path);

--- a/src/ac_jsonw.c
+++ b/src/ac_jsonw.c
@@ -217,19 +217,21 @@ void ac_jsonw_add_real(ac_jsonw_t *json, const char *name, double value,
 		       int dp)
 {
 	char fmt[32] = "\0";
+	const char *pfmt = fmt;
 	int len = 0;
 
 	if (name)
 		len = sprintf(fmt, "\"%%s\": ");
+
 	if (dp == -1)
 		sprintf(fmt + len, "%%f,\n");
 	else
 		snprintf(fmt + len, sizeof(fmt) - len, "%%.%df,\n", dp);
 
 	if (name)
-		json_build_str(json, fmt, name, value);
+		json_build_str(json, pfmt, name, value);
 	else
-		json_build_str(json, fmt, value);
+		json_build_str(json, pfmt, value);
 }
 
 /**


### PR DESCRIPTION
GitHub code scanning picked up a potential problem in ac_fs_mkdir_p() where we could overwrite the last '\0' in mdir[] with a '/'.

We need to make mdir 1 bigger to allow for the fact that we add a trailing '/' to the end of the directory path each time around the loop, ready for the next directory component to get added.

Switch to using PATH_MAX for the buffer size and add 1 to it, we can then just against PATH_MAX for the path length rather than the size of the mdir buffer.

Signed-off-by: Andrew Clayton <andrew@digital-domain.net>