### PR TITLE
Make use of __attribute__((nonstring)) to quell new GCC 15 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ Glibc.
 
 These are aliases for \_\_attribute\_\_((unused))
 
+    #define __nonstring
+
+This is an alias for \_\_attribute\_\_((nonstring))
+
     #define AC_FS_COPY_OVERWRITE
 
     #define AC_UUID4_LEN	36

--- a/src/ac_misc.c
+++ b/src/ac_misc.c
@@ -3,8 +3,7 @@
 /*
  * ac_misc.c - Miscellaneous functions
  *
- * Copyright (c) 2017, 2019 - 2021	Andrew Clayton
- *					<andrew@digital-domain.net>
+ * Copyright (c) 2017 - 2025	Andrew Clayton <ac@sigsegv.uk>
  */
 
 #define _GNU_SOURCE
@@ -116,7 +115,7 @@ void ac_misc_ppb(u64 bytes, ac_si_units_t si, ac_misc_ppb_t *ppb)
 char *ac_misc_passcrypt(const char *pass, ac_hash_algo_t hash_type,
 			ac_crypt_data_t *data)
 {
-	const char salt_chars[64] =
+	static const char salt_chars[64] __nonstring =
 		"./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 	char salt[21];
 	char statebuf[PRNG_BUFSZ];

--- a/src/include/libac.h
+++ b/src/include/libac.h
@@ -3,8 +3,7 @@
 /*
  * libac.h - Miscellaneous functions
  *
- * Copyright (c) 2017 - 2020 - 2022	Andrew Clayton
- *					<andrew@digital-domain.net>
+ * Copyright (c) 2017 - 2025	Andrew Clayton <ac@sigsegv.uk>
  */
 
 #ifndef _LIBAC_H_
@@ -47,6 +46,14 @@ typedef int8_t    s8;
 #endif
 #ifndef __always_unused
 #define __always_unused		__attribute__((unused))
+#endif
+
+#ifndef __nonstring
+#if (defined(__GNUC__) && !defined(__clang__))
+#define __nonstring		__attribute__((nonstring))
+#else
+#define __nonstring
+#endif
 #endif
 
 typedef struct crypt_data ac_crypt_data_t;


### PR DESCRIPTION
* Add a macro wrapper `__nonstring` around `__attribute__((nonstring))`
* Make use of this new wrapper in `ac_misc_passcrypt()`

